### PR TITLE
Security updates

### DIFF
--- a/Remember The Date.xcodeproj/project.pbxproj
+++ b/Remember The Date.xcodeproj/project.pbxproj
@@ -499,6 +499,9 @@
 						DevelopmentTeam = 689VA4CD22;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
+							com.apple.DataProtection = {
+								enabled = 1;
+							};
 							com.apple.Push = {
 								enabled = 1;
 							};

--- a/Remember The Date/Info.plist
+++ b/Remember The Date/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.11.3</string>
+	<string>1.11.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/Remember The Date/Remember The Date.entitlements
+++ b/Remember The Date/Remember The Date.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.default-data-protection</key>
+	<string>NSFileProtectionComplete</string>
 </dict>
 </plist>

--- a/Remember The Date/View Controllers/CreateProfileTableViewController.m
+++ b/Remember The Date/View Controllers/CreateProfileTableViewController.m
@@ -38,6 +38,7 @@ extern NSString *APNS_ID_KEY;
         self.nameTextField.text         = [defaults stringForKey:@"userName"];
         self.emailTextField.text        = [defaults stringForKey:@"email"];
         self.passwordTextField.text     = [defaults stringForKey:@"password"];
+        [self.passwordTextField setSecureTextEntry:YES];
         
         [self.navigationItem.rightBarButtonItem setTitle:NSLocalizedString(@"Save", @"")];
         


### PR DESCRIPTION
Updates from Sec Dev. 

* Adding data protection capability. We do store sensitive info in NSUserDefaults.
* Made the "password" input secure so 3rd party keyboards can't log it.

@RonanMcH @tecknut 